### PR TITLE
GH-3: Convert Array Mail Headers to Lists

### DIFF
--- a/spring-cloud-starter-stream-source-mail/src/main/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfiguration.java
+++ b/spring-cloud-starter-stream-source-mail/src/main/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.app.mail.source;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 import javax.mail.URLName;
@@ -28,12 +30,18 @@ import org.springframework.cloud.stream.app.trigger.TriggerPropertiesMaxMessages
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.integration.dsl.HeaderEnricherSpec;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.mail.Mail;
 import org.springframework.integration.dsl.mail.MailInboundChannelAdapterSpec;
+import org.springframework.integration.dsl.support.Consumer;
 import org.springframework.integration.dsl.support.Transformers;
+import org.springframework.integration.mail.MailHeaders;
+import org.springframework.integration.transformer.support.AbstractHeaderValueMessageProcessor;
+import org.springframework.integration.transformer.support.HeaderValueMessageProcessor;
+import org.springframework.messaging.Message;
 
 /**
  * A source module that listens for mail and emits the content as a message payload.
@@ -53,8 +61,30 @@ public class MailSourceConfiguration {
 	public IntegrationFlow mailInboundFlow() {
 		return getFlowBuilder()
 				.transform(Transformers.fromMail(this.properties.getCharset()))
+				.enrichHeaders(new Consumer<HeaderEnricherSpec>() {
+
+					@Override
+					public void accept(HeaderEnricherSpec h) {
+						h.defaultOverwrite(true)
+							.header(MailHeaders.TO, arrayToListProcessor(MailHeaders.TO))
+							.header(MailHeaders.CC, arrayToListProcessor(MailHeaders.CC))
+							.header(MailHeaders.BCC, arrayToListProcessor(MailHeaders.BCC));
+					}
+
+				})
 				.channel(Source.OUTPUT)
 				.get();
+	}
+
+	private HeaderValueMessageProcessor<?> arrayToListProcessor(final String header) {
+		return new AbstractHeaderValueMessageProcessor<List<String>>() {
+
+			@Override
+			public List<String> processMessage(Message<?> message) {
+				return Arrays.asList(message.getHeaders().get(header, String[].class));
+			}
+
+		};
 	}
 
 	/**

--- a/spring-cloud-starter-stream-source-mail/src/test/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfigurationTests.java
+++ b/spring-cloud-starter-stream-source-mail/src/test/java/org/springframework/cloud/stream/app/mail/source/MailSourceConfigurationTests.java
@@ -16,11 +16,14 @@
 
 package org.springframework.cloud.stream.app.mail.source;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matchers;
@@ -35,10 +38,12 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.stream.messaging.Source;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
+import org.springframework.integration.mail.MailHeaders;
 import org.springframework.integration.mail.transformer.MailToStringTransformer;
 import org.springframework.integration.test.mail.TestMailServer;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -103,8 +108,15 @@ public abstract class MailSourceConfigurationTests {
 
 			Message<?> received = this.messageCollector.forChannel(source.output()).poll(10, TimeUnit.SECONDS);
 			assertNotNull(received);
-			assertThat(received.getPayload(), Matchers.instanceOf(String.class));
+			assertThat(received.getPayload(), instanceOf(String.class));
 			assertEquals("foo\r\n\r\n", received.getPayload());
+			MessageHeaders headers = received.getHeaders();
+			assertThat(headers.get(MailHeaders.TO), instanceOf(List.class));
+			assertThat(headers.get(MailHeaders.CC), instanceOf(List.class));
+			assertThat(headers.get(MailHeaders.BCC), instanceOf(List.class));
+			assertThat(headers.get(MailHeaders.TO).toString(), equalTo("[Foo <foo@bar>]"));
+			assertThat(headers.get(MailHeaders.CC).toString(), equalTo("[]"));
+			assertThat(headers.get(MailHeaders.BCC).toString(), equalTo("[]"));
 		}
 
 	}


### PR DESCRIPTION
Fixes #3 

Convert array-based mail headers to lists for proper conveyance over RabbitMQ.